### PR TITLE
Dragend not catched in some cases

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,12 +59,14 @@ export default class Scrollzone extends React.Component {
   attach() {
     window.document.body.addEventListener('dragover', this.updateScrolling);
     window.document.body.addEventListener('dragend', this.stopScrolling);
+    window.document.body.addEventListener('drop', this.stopScrolling);
     this.attached = true;
   }
 
   detach() {
     window.document.body.removeEventListener('dragover', this.updateScrolling);
     window.document.body.removeEventListener('dragend', this.stopScrolling);
+    window.document.body.removeEventListener('drop', this.stopScrolling);
     this.attached = false;
   }
 


### PR DESCRIPTION
Hi, `react-dnd-scrollzone` helped me a lot. Thanks for open-sourcing your work.

I have a usecase which basically looks like:

```
<scrollzone>
   <draggable1>
      <draggable2/>
      <draggable2/>
   </draggable1>
    <draggable1>
      <draggable2/>
      <draggable2/>
   </draggable1>
</scrollzone>
```

When drag-dropping a `<draggable2>` in another `<draggable1>`, the event `dragend` is not fired which causes the scroll to drift indefinitely. I fixed that by also listening to the drop event.