### PR TITLE
Allow custom scroll container

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Apply the withScrolling function to any html-identifier ("div", "ul" etc) or rea
  * `verticalStrength` - a function that returns the strength of the vertical scroll direction
  * `strengthMultiplier` - strength multiplier, play around with this (default 30)
  * `onScrollChange` - a function that is called when `scrollLeft` or `scrollTop` of the component are changed. Called with those two arguments in that order.
+ * `scrollContainer` - a custom Element to attach event listeners to for scrolling. Defaults to the wrapped react component.
 
 The strength functions are both called with two arguments. An object representing the rectangle occupied by the Scrollzone, and an object representing the coordinates of mouse.
 

--- a/src/index.js
+++ b/src/index.js
@@ -60,6 +60,7 @@ export default function createScrollingComponent(WrappedComponent) {
       verticalStrength: PropTypes.func,
       horizontalStrength: PropTypes.func,
       strengthMultiplier: PropTypes.number,
+      scrollContainer: PropTypes.instanceOf(typeof Element !== 'undefined' ? Element : Object),
     };
 
     static defaultProps = {
@@ -85,7 +86,7 @@ export default function createScrollingComponent(WrappedComponent) {
     }
 
     componentDidMount() {
-      this.container = findDOMNode(this.wrappedInstance);
+      this.container = this.props.scrollContainer || findDOMNode(this.wrappedInstance);
       this.container.addEventListener('dragover', this.handleEvent);
       // touchmove events don't seem to work across siblings, so we unfortunately
       // have to attach the listeners to the body


### PR DESCRIPTION
This adds the ability to set scroll containers other than the wrapped
component for more custom implementations.

For example, combining `react-dnd-scrollzone` with `react-virtualized`, and using `WindowScroller` with the `scrollElement` prop, `react-dnd-scrollzone` needs a way to set its `container` as the same `scrollElement` that `WindowScroller` uses to properly listen on scrollable areas.

This is somewhat different than https://github.com/azuqua/react-dnd-scrollzone/pull/20, as this change allows you to manually set the scroll container you want to use.

Fixes #32 

Tested in Chrome, Safari, FireFox, and IE11