### PR TITLE
Support latest versions of react-dnd, and other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Apply the withScrolling function to any html-identifier ("div", "ul" etc) or rea
  * `verticalStrength` - a function that returns the strength of the vertical scroll direction
  * `strengthMultiplier` - strength multiplier, play around with this (default 30)
  * `onScrollChange` - a function that is called when `scrollLeft` or `scrollTop` of the component are changed. Called with those two arguments in that order.
+ * `getScrollContainer` - optional parameter: a function that returns scrolling container (useful for complex custom scroll components). It recieves one argument: root node of wrapped mounted component
 
 The strength functions are both called with two arguments. An object representing the rectangle occupied by the Scrollzone, and an object representing the coordinates of mouse.
 

--- a/package.json
+++ b/package.json
@@ -70,6 +70,6 @@
   "peerDependencies": {
     "react": "15.1 - 16",
     "react-dom": "15.1 - 16",
-    "react-dnd": "2 - 5"
+    "react-dnd": "2 - 6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "sinon-chai": "^2.8.0",
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
-    "react-dnd": "^5.0.0"
+    "react-dnd": "^6.0.0"
   },
   "peerDependencies": {
     "react": "15.1 - 16",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "4.0.0",
   "description": "A cross browser solution to scrolling during drag and drop.",
   "main": "lib/index.js",
+  "typings": "typings/index.d.ts",
+  "sideEffects": false,
   "scripts": {
     "build": "rm -rf lib && babel src --out-dir lib",
     "lint": "eslint src",
@@ -59,9 +61,15 @@
     "eslint-plugin-react": "^5.1.1",
     "in-publish": "^2.0.0",
     "mocha": "^2.3.4",
-    "react": "^15.1.0",
-    "react-dom": "^15.1.0",
     "sinon": "^1.17.2",
-    "sinon-chai": "^2.8.0"
+    "sinon-chai": "^2.8.0",
+    "react": "^16.5.0",
+    "react-dom": "^16.5.0",
+    "react-dnd": "^5.0.0"
+  },
+  "peerDependencies": {
+    "react": "15.1 - 16",
+    "react-dom": "15.1 - 16",
+    "react-dnd": "2 - 5"
   }
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,0 +1,31 @@
+import { ComponentType } from 'react';
+
+type StrengthFunction = (
+    rect: {
+        x: number; 
+        y: number;
+        w: number;
+        h: number;
+    }, 
+    point: {
+        x: number;
+        y: number;
+    }
+) => number;
+
+declare function createHorizontalStrength(_buffer: number): StrengthFunction;
+declare function createVerticalStrength(_buffer: number): StrengthFunction;
+
+declare const defaultHorizontalStrength: StrengthFunction;
+declare const defaultVerticalStrength: StrengthFunction;
+
+interface IScrollingInjectedProps {
+    onScrollChange?: (left: number, top: number) => void,
+    verticalStrength?: StrengthFunction;
+    horizontalStrength?: StrengthFunction;
+    strengthMultiplier?: number;
+    getScrollContainer?: (element: HTMLElement) => HTMLElement;
+}
+
+declare function createScrollingComponent<Props>(Component: ComponentType<Props> ): ComponentType<Props & IScrollingInjectedProps>;
+export default createScrollingComponent;


### PR DESCRIPTION
react-dnd-scrollzone don't work with react-dnd >= 4.0.0, because it uses new React context API (Provider/Consumer from React 16.3).

This PR add support latest versions of react-dnd, which uses new React context API, and still supports old 
react-dnd version, which uses old-style context api.

Another changes:

Add getScrollContainer - optional parameter: a function that returns scrolling container (useful for complex custom scroll components). It recieves one argument: root node of wrapped mounted component.
Add typings for Typescript
Add sideEffects: false parameter to package.json to optimize Webpack4 bundles