### PR TITLE
Don't hoist getDerivedStateFromProps.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "hoist-non-react-statics": "^1.2.0",
+    "hoist-non-react-statics": "3.x",
     "lodash.throttle": "^4.0.1",
     "prop-types": "^15.5.9",
     "raf": "^3.2.0",
@@ -59,8 +59,8 @@
     "eslint-plugin-react": "^5.1.1",
     "in-publish": "^2.0.0",
     "mocha": "^2.3.4",
-    "react": "^15.1.0",
-    "react-dom": "^15.1.0",
+    "react": "16.x",
+    "react-dom": "16.x",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0"
   }


### PR DESCRIPTION
Upgrade hoist-non-react-statics so that getDerivedStateFromProps isn't hoisted. This allows the library to be used with react v16.